### PR TITLE
Demo: Trigger image pull failure via invalid tag (GitOps workflow)

### DIFF
--- a/nextjs/values.yaml
+++ b/nextjs/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: mrfour4uit/seminar-demo
-  tag: b635b849f40f86ee80163785215e2ceeec489b1e
+  tag: "image-not-found-demo"  # clearly fake tag for demo
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
### What
This PR sets an intentionally invalid Docker image tag (`image-not-found-demo`) to simulate an image pull failure during deployment.

### Why
To demonstrate how the GitOps pipeline (with Argo CD) reacts to failed image pulls, showing error handling and sync failure status.

### Changes
- Updated Helm values to use a non-existent image tag
- Deployment is expected to fail with `ImagePullBackOff`

### Notes
- This PR is for demo purposes only
- A follow-up PR will restore the correct image tag and complete the cycle
